### PR TITLE
NS-45: Add sibling pointer support to Node structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+/target/
+Cargo.lock
+*.tmp
+*.bak
+.DS_Store

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,20 @@
 # CLAUDE.md
 
+🚨 **STOP - READ WORKFLOW FIRST** 🚨
+Before doing ANYTHING else, you MUST read the development workflow:
+1. Read: `../nodespace-system-design/docs/development-workflow.md`
+2. Check Linear for current tasks
+3. Then return here for implementation guidance
+
+❌ **FORBIDDEN:** Any code analysis, planning, or implementation before reading the workflow
+
+## Development Workflow
+**ALWAYS start with README.md** - This file contains the authoritative development workflow and setup instructions for this repository.
+
+**Then return here** for repository-specific guidance and architecture details.
+
+## Project Overview
+
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
 ## Repository Purpose
@@ -8,14 +23,17 @@ This is `nodespace-core-types`, the **foundational types repository** for the No
 
 **Key responsibility**: Define core types (`Node`, `NodeId`, `NodeSpaceResult`, `NodeSpaceError`) that enable type-safe communication across all NodeSpace services.
 
+## 🎯 FINDING YOUR NEXT TASK
+
+**See [development-workflow.md](../nodespace-system-design/docs/development-workflow.md)** for task management workflow.
+
 ## Getting Started
 
 **New to NodeSpace? Start Here:**
 1. **Read [NodeSpace System Design](../nodespace-system-design/README.md)** - Understand the full architecture
-2. **Check [Linear workspace](https://linear.app/nodespace)** - Find current tasks (filter by `nodespace-core-types`)
-3. **Review [Development Workflow](../nodespace-system-design/docs/development-workflow.md)** - Process and procedures
-4. **Study [Service Contracts](../nodespace-system-design/contracts/)** - See how your types are used
-5. **See [MVP User Flow](../nodespace-system-design/examples/mvp-user-flow.md)** - What you're building
+2. **Review [Development Workflow](../nodespace-system-design/docs/development-workflow.md)** - Process and procedures
+3. **Study [Service Contracts](../nodespace-system-design/contracts/)** - See how your types are used
+4. **See [MVP User Flow](../nodespace-system-design/examples/mvp-user-flow.md)** - What you're building
 
 ## Development Setup
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+# ⚠️ BEFORE STARTING ANY WORK
+👉 **STEP 1**: Read development workflow: `../nodespace-system-design/docs/development-workflow.md`
+👉 **STEP 2**: Check Linear for assigned tasks
+👉 **STEP 3**: Repository-specific patterns below
+
+**This README.md only contains**: Repository-specific type definitions and Rust patterns
+
 # NodeSpace Core Types
 
 **Shared data structures and interfaces for NodeSpace multi-session development environment**

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,9 @@ pub struct Node {
     pub metadata: Option<serde_json::Value>, // Optional system metadata
     pub created_at: String,                  // ISO format timestamp
     pub updated_at: String,                  // ISO format timestamp
+    // Sibling pointer fields for sequential navigation
+    pub next_sibling: Option<NodeId>, // → Next node in sequence (None = last)
+    pub previous_sibling: Option<NodeId>, // ← Previous node in sequence (None = first)
 }
 
 impl Node {
@@ -67,6 +70,8 @@ impl Node {
             metadata: None,
             created_at: now.clone(),
             updated_at: now,
+            next_sibling: None,
+            previous_sibling: None,
         }
     }
 
@@ -79,6 +84,8 @@ impl Node {
             metadata: None,
             created_at: now.clone(),
             updated_at: now,
+            next_sibling: None,
+            previous_sibling: None,
         }
     }
 
@@ -91,6 +98,57 @@ impl Node {
     /// Update the node's timestamp
     pub fn touch(&mut self) {
         self.updated_at = chrono::Utc::now().to_rfc3339();
+    }
+
+    /// Set the next sibling pointer
+    pub fn with_next_sibling(mut self, next_sibling: Option<NodeId>) -> Self {
+        self.next_sibling = next_sibling;
+        self
+    }
+
+    /// Set the previous sibling pointer
+    pub fn with_previous_sibling(mut self, previous_sibling: Option<NodeId>) -> Self {
+        self.previous_sibling = previous_sibling;
+        self
+    }
+
+    /// Set both sibling pointers
+    pub fn with_siblings(mut self, previous: Option<NodeId>, next: Option<NodeId>) -> Self {
+        self.previous_sibling = previous;
+        self.next_sibling = next;
+        self
+    }
+
+    /// Update sibling pointers
+    pub fn set_next_sibling(&mut self, next_sibling: Option<NodeId>) {
+        self.next_sibling = next_sibling;
+        self.touch();
+    }
+
+    /// Update previous sibling pointer
+    pub fn set_previous_sibling(&mut self, previous_sibling: Option<NodeId>) {
+        self.previous_sibling = previous_sibling;
+        self.touch();
+    }
+
+    /// Check if this node has a next sibling
+    pub fn has_next_sibling(&self) -> bool {
+        self.next_sibling.is_some()
+    }
+
+    /// Check if this node has a previous sibling
+    pub fn has_previous_sibling(&self) -> bool {
+        self.previous_sibling.is_some()
+    }
+
+    /// Check if this node is first in sequence (no previous sibling)
+    pub fn is_first(&self) -> bool {
+        self.previous_sibling.is_none()
+    }
+
+    /// Check if this node is last in sequence (no next sibling)
+    pub fn is_last(&self) -> bool {
+        self.next_sibling.is_none()
     }
 }
 
@@ -308,5 +366,148 @@ mod tests {
         let error: NodeSpaceResult<String> =
             Err(NodeSpaceError::ValidationError("Invalid input".to_string()));
         assert!(error.is_err());
+    }
+
+    #[test]
+    fn test_node_sibling_pointers() {
+        let content = json!({"text": "Hello World"});
+        let node = Node::new(content);
+
+        // New nodes should have no siblings
+        assert!(node.next_sibling.is_none());
+        assert!(node.previous_sibling.is_none());
+        assert!(node.is_first());
+        assert!(node.is_last());
+        assert!(!node.has_next_sibling());
+        assert!(!node.has_previous_sibling());
+    }
+
+    #[test]
+    fn test_node_with_siblings() {
+        let content = json!({"text": "Middle Node"});
+        let prev_id = NodeId::new();
+        let next_id = NodeId::new();
+
+        let node = Node::new(content).with_siblings(Some(prev_id.clone()), Some(next_id.clone()));
+
+        assert_eq!(node.previous_sibling, Some(prev_id));
+        assert_eq!(node.next_sibling, Some(next_id));
+        assert!(!node.is_first());
+        assert!(!node.is_last());
+        assert!(node.has_next_sibling());
+        assert!(node.has_previous_sibling());
+    }
+
+    #[test]
+    fn test_node_sibling_builder_methods() {
+        let content = json!({"text": "Test Node"});
+        let next_id = NodeId::new();
+        let prev_id = NodeId::new();
+
+        let node = Node::new(content)
+            .with_next_sibling(Some(next_id.clone()))
+            .with_previous_sibling(Some(prev_id.clone()));
+
+        assert_eq!(node.next_sibling, Some(next_id));
+        assert_eq!(node.previous_sibling, Some(prev_id));
+    }
+
+    #[test]
+    fn test_node_sibling_mutation() {
+        let content = json!({"text": "Mutable Node"});
+        let mut node = Node::new(content);
+
+        let next_id = NodeId::new();
+        let prev_id = NodeId::new();
+
+        // Test setting next sibling
+        node.set_next_sibling(Some(next_id.clone()));
+        assert_eq!(node.next_sibling, Some(next_id));
+        assert!(node.has_next_sibling());
+        assert!(!node.is_last());
+
+        // Test setting previous sibling
+        node.set_previous_sibling(Some(prev_id.clone()));
+        assert_eq!(node.previous_sibling, Some(prev_id));
+        assert!(node.has_previous_sibling());
+        assert!(!node.is_first());
+
+        // Test clearing siblings
+        node.set_next_sibling(None);
+        node.set_previous_sibling(None);
+        assert!(node.is_first());
+        assert!(node.is_last());
+    }
+
+    #[test]
+    fn test_node_sequence_chain() {
+        // Create a chain of 3 nodes: A -> B -> C
+        let node_a = Node::new(json!({"text": "Node A"}));
+        let node_b = Node::new(json!({"text": "Node B"}));
+        let node_c = Node::new(json!({"text": "Node C"}));
+
+        let a_id = node_a.id.clone();
+        let b_id = node_b.id.clone();
+        let c_id = node_c.id.clone();
+
+        // Set up the chain
+        let node_a = node_a.with_next_sibling(Some(b_id.clone()));
+        let node_b = node_b
+            .with_previous_sibling(Some(a_id.clone()))
+            .with_next_sibling(Some(c_id.clone()));
+        let node_c = node_c.with_previous_sibling(Some(b_id.clone()));
+
+        // Test chain properties
+        assert!(node_a.is_first());
+        assert!(!node_a.is_last());
+        assert_eq!(node_a.next_sibling, Some(b_id.clone()));
+
+        assert!(!node_b.is_first());
+        assert!(!node_b.is_last());
+        assert_eq!(node_b.previous_sibling, Some(a_id));
+        assert_eq!(node_b.next_sibling, Some(c_id.clone()));
+
+        assert!(!node_c.is_first());
+        assert!(node_c.is_last());
+        assert_eq!(node_c.previous_sibling, Some(b_id));
+    }
+
+    #[test]
+    fn test_node_sibling_serialization() {
+        let prev_id = NodeId::new();
+        let next_id = NodeId::new();
+        let content = json!({"text": "Serialization Test"});
+
+        let node = Node::new(content).with_siblings(Some(prev_id.clone()), Some(next_id.clone()));
+
+        // Test serialization
+        let serialized = serde_json::to_string(&node).unwrap();
+        let deserialized: Node = serde_json::from_str(&serialized).unwrap();
+
+        assert_eq!(node.id, deserialized.id);
+        assert_eq!(node.content, deserialized.content);
+        assert_eq!(node.next_sibling, deserialized.next_sibling);
+        assert_eq!(node.previous_sibling, deserialized.previous_sibling);
+        assert_eq!(deserialized.previous_sibling, Some(prev_id));
+        assert_eq!(deserialized.next_sibling, Some(next_id));
+    }
+
+    #[test]
+    fn test_node_backward_compatibility() {
+        // Test that nodes without sibling fields can still be deserialized
+        let json_without_siblings = r#"{
+            "id": "test-id-123",
+            "content": {"text": "Legacy Node"},
+            "metadata": null,
+            "created_at": "2024-01-01T00:00:00Z",
+            "updated_at": "2024-01-01T00:00:00Z"
+        }"#;
+
+        let node: Node = serde_json::from_str(json_without_siblings).unwrap();
+        assert_eq!(node.id.as_str(), "test-id-123");
+        assert!(node.next_sibling.is_none());
+        assert!(node.previous_sibling.is_none());
+        assert!(node.is_first());
+        assert!(node.is_last());
     }
 }


### PR DESCRIPTION
## Summary
- Add `next_sibling` and `previous_sibling` fields to Node structure for sequential navigation
- Implement comprehensive helper methods for sibling pointer management
- Add extensive test coverage including serialization, chain building, and backward compatibility
- Ensure all tests pass and maintain code quality standards

## Test plan
- [x] Run `cargo test` - All 17 tests pass
- [x] Run `cargo fmt --check` - Code formatting is clean
- [x] Run `cargo clippy -- -D warnings` - No linting warnings
- [x] Verify backward compatibility with legacy JSON deserialization
- [x] Test sibling pointer builder methods and mutation functions
- [x] Validate sequence chain operations and navigation helpers

Resolves NS-45

Generated with [Claude Code](https://claude.ai/code)