### PR TITLE
NS-56: Update documentation references to reflect distributed contract architecture

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ This is `nodespace-core-types`, the **foundational types repository** for the No
 **New to NodeSpace? Start Here:**
 1. **Read [NodeSpace System Design](../nodespace-system-design/README.md)** - Understand the full architecture
 2. **Review [Development Workflow](../nodespace-system-design/docs/development-workflow.md)** - Process and procedures
-3. **Study [Service Contracts](../nodespace-system-design/contracts/)** - See how your types are used
+3. **See distributed service interfaces** - Services own their interface traits and import types from this repository
 4. **See [MVP User Flow](../nodespace-system-design/examples/mvp-user-flow.md)** - What you're building
 
 ## Development Setup
@@ -56,7 +56,7 @@ Since this is a Rust crate for type definitions, the primary commands are:
 # Validate all contracts compile
 cargo check
 
-# Run contract compliance tests  
+# Run type validation tests  
 cargo test
 
 # Test that downstream repos can use these types
@@ -89,7 +89,7 @@ This repository sits at the foundation of the NodeSpace system architecture:
 
 **Dependency-Based Architecture**: This repository defines minimal essential types that other repositories import via Cargo dependencies. 
 
-**DO NOT copy contracts** - Service interfaces are defined in `nodespace-system-design/contracts/` and import types from this repository.
+**Distributed contract ownership** - Each service repository owns its interface traits and imports types from this repository.
 
 **Focus**: Define clean, minimal types that serve as the foundation for all other repositories.
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ This repository has **no dependencies** on other NodeSpace repositories. All oth
 1. **Read [NodeSpace System Design](../nodespace-system-design/README.md)** - Understand the full architecture
 2. **Check [Linear workspace](https://linear.app/nodespace)** - Find your current tasks (filter by `nodespace-core-types`)
 3. **Review [Development Workflow](../nodespace-system-design/docs/development-workflow.md)** - Process and procedures
-4. **Study [Service Contracts](../nodespace-system-design/contracts/)** - See how your types are used in service interfaces
+4. **See distributed service interfaces** - Services own their interface traits and import types from this repository
 5. **See [MVP User Flow](../nodespace-system-design/examples/mvp-user-flow.md)** - What you're building
 
 ### **Development Setup:**
@@ -67,7 +67,7 @@ Part of the [NodeSpace system architecture](../nodespace-system-design/README.md
 # Validate all contracts compile
 cargo check
 
-# Run contract compliance tests  
+# Run type validation tests  
 cargo test
 
 # Check that other repos can use these types


### PR DESCRIPTION
Resolves NS-56

## Summary

Updated documentation in README.md and CLAUDE.md to remove outdated references to centralized contracts and reflect the current distributed architecture where services own their interface traits.

## Changes Made

- **README.md**: 
  - Removed centralized contracts directory reference (line 39)
  - Changed "contract compliance tests" to "type validation tests" (lines 70-71)
  
- **CLAUDE.md**: 
  - Removed centralized contracts reference (line 35)
  - Updated "contract compliance tests" to "type validation tests" (lines 59-60)
  - Updated guidance about contract ownership to reflect distributed architecture (line 92)

## Testing

- [x] All changes verified: cargo check passes
- [x] Formatting clean: cargo fmt --check passes
- [x] Documentation accurately reflects distributed contract ownership model

The repository code is correctly structured - only documentation needed updating to reflect that services own their interface traits and import types from this repository.

🤖 Generated with [Claude Code](https://claude.ai/code)